### PR TITLE
Allows relative !includes to work when importing via http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.raml</groupId>
             <artifactId>raml-parser</artifactId>
-            <version>0.9-SNAPSHOT</version>
+            <version>0.8.12</version>
         </dependency>
 
         <dependency>

--- a/src/main/groovy/com/smartbear/soapui/raml/RamlImporter.groovy
+++ b/src/main/groovy/com/smartbear/soapui/raml/RamlImporter.groovy
@@ -68,7 +68,7 @@ class RamlImporter {
             raml = new RamlDocumentBuilder().build(new URL(url).openStream(), parent );
         }
         else {
-            raml = new RamlDocumentBuilder().build(new URL(url).openStream());
+            raml = new RamlDocumentBuilder().build(url);
         }
 
         def service = createRestService(raml)


### PR DESCRIPTION
- Triggering the build with this call allows the raml-parser
  to set contextPath into the IncludeResolver's
